### PR TITLE
Tiny build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.21)
 
 project(asm)
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ou pipefail
 
-mkdir build
+mkdir -p build
 cd build || exit
 cmake ..
 make


### PR DESCRIPTION
Commits descriptions say pretty much everything. Key points:
1. Use `mkdir -p build` instead of `mkdir build` to never get an error that `build` already exists
2. Compatibility with CMake < 3.10 is deprecated, hence `cmake_minimum_required(VERSION 2.8...3.31)` is used to tell CMake that `CMakeLists.txt` works fine with the newest release (3.31)